### PR TITLE
fix: configure env vars for monorepo structure

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,6 +4,7 @@ import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
+  envDir: '../', // Look for .env files in parent directory (project root)
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
- Add .env.local to project root
- Configure Vite envDir to read from parent directory
- Ensure NEXT_PUBLIC_BACKEND_BASE loads correctly

🤖 Generated with [Claude Code](https://claude.ai/code)