### PR TITLE
fix: hide connection status when connected successfully

### DIFF
--- a/client/src/components/ConnectionStatus.tsx
+++ b/client/src/components/ConnectionStatus.tsx
@@ -67,11 +67,6 @@ export function ConnectionStatus() {
     );
   }
 
-  // Lambda 직접 호출 모드 안내
-  return (
-    <div className="flex items-center space-x-2 bg-green-50 text-green-700 px-3 py-2 rounded-lg text-sm">
-      <Wifi className="w-4 h-4" />
-      <span>Lambda 직접 연결 모드 (임시 우회)</span>
-    </div>
-  );
+  // 연결 성공 - 메시지 표시 안함 (UI 간소화)
+  return null;
 }


### PR DESCRIPTION
- Remove "Lambda direct connection mode" message for cleaner UI
- Only show connection status when there are issues
- Keep error states and offline detection intact

🤖 Generated with [Claude Code](https://claude.ai/code)